### PR TITLE
Refactored Dispatcher methods utilizing some of Linqs awesomeness.

### DIFF
--- a/FluxSharp.UI/Abstractions/Dispatcher.cs
+++ b/FluxSharp.UI/Abstractions/Dispatcher.cs
@@ -1,53 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FluxSharp.Abstractions
 {
     public class Dispatcher
     {
-        readonly Dictionary<Type, List<object>> callbacks
-            = new Dictionary<Type, List<object>>();
+        private readonly IDictionary<Type, IList<object>> _callbacks =
+            new Dictionary<Type, IList<object>>();
 
         public void Register<T>(Action<T> callback)
         {
             var key = typeof(T);
 
-            if (callbacks.ContainsKey(key))
-            {
-                var currentCallbacks = callbacks[key];
-                currentCallbacks.Add(callback);
-            }
-            else
-            {
-                var newCallbacks = new List<object> { callback };
-                callbacks.Add(key, newCallbacks);
-            }
+            if(!_callbacks.ContainsKey(key))
+                _callbacks.Add(key, new List<object>());
+
+            _callbacks[key].Add(callback);
         }
 
         public void Dispatch<T>(T payload)
         {
             var key = typeof(T);
 
-            if (callbacks.ContainsKey(key))
-            {
-                var currentCallbacks = callbacks[key];
-                foreach (var c in currentCallbacks)
-                {
-                    Action<T> convertedCallback = c as Action<T>;
-                    if (convertedCallback == null)
-                    {
-                        // TODO: whut?
-                    }
-                    else
-                    {
-                        convertedCallback(payload);
-                    }
-                }
-            }
-            else
-            {
-                // TODO: whut?
-            }
+            if (!_callbacks.ContainsKey(key))
+                return;
+
+            _callbacks[key]
+                .OfType<Action<T>>()
+                .ToList()
+                .ForEach(callback => callback(payload));
         }
     }
 }


### PR DESCRIPTION
Thought it might be a nice idea to use the OfType<T> method so we don't have to check each action type manually.

Also changed the callbacks dictionary to interfaces (just a personal preference).

Changed the way we register a callback. No need to have an if/else in there, especially if the KVP is adding a list. I feel it is much cleaner to initialize a new KVP with an initialized list, and then add the value in to the list.
